### PR TITLE
nf: IDLETIMER: Adds the uid field in the msg

### DIFF
--- a/net/netfilter/xt_IDLETIMER.c
+++ b/net/netfilter/xt_IDLETIMER.c
@@ -48,6 +48,7 @@
 #include <linux/suspend.h>
 #include <linux/notifier.h>
 #include <net/net_namespace.h>
+#include <net/sock.h>
 
 struct idletimer_tg_attr {
 	struct attribute attr;
@@ -73,6 +74,7 @@ struct idletimer_tg {
 	bool work_pending;
 	bool send_nl_msg;
 	bool active;
+	uid_t uid;
 };
 
 static LIST_HEAD(idletimer_tg_list);
@@ -117,7 +119,8 @@ static void notify_netlink_uevent(const char *iface, struct idletimer_tg *timer)
 	char iface_msg[NLMSG_MAX_SIZE];
 	char state_msg[NLMSG_MAX_SIZE];
 	char timestamp_msg[NLMSG_MAX_SIZE];
-	char *envp[] = { iface_msg, state_msg, timestamp_msg, NULL };
+	char uid_msg[NLMSG_MAX_SIZE];
+	char *envp[] = { iface_msg, state_msg, timestamp_msg, uid_msg, NULL };
 	int res;
 	struct timespec ts;
 	uint64_t time_ns;
@@ -140,6 +143,16 @@ static void notify_netlink_uevent(const char *iface, struct idletimer_tg *timer)
 		return;
 	}
 
+	if (state) {
+		res = snprintf(uid_msg, NLMSG_MAX_SIZE, "UID=%u", timer->uid);
+		if (NLMSG_MAX_SIZE <= res)
+			pr_err("message too long (%d)", res);
+	} else {
+		res = snprintf(uid_msg, NLMSG_MAX_SIZE, "UID=");
+		if (NLMSG_MAX_SIZE <= res)
+			pr_err("message too long (%d)", res);
+	}
+
 	time_ns = timespec_to_ns(&ts);
 	res = snprintf(timestamp_msg, NLMSG_MAX_SIZE, "TIME_NS=%llu", time_ns);
 	if (NLMSG_MAX_SIZE <= res) {
@@ -147,7 +160,8 @@ static void notify_netlink_uevent(const char *iface, struct idletimer_tg *timer)
 		pr_err("message too long (%d)", res);
 	}
 
-	pr_debug("putting nlmsg: <%s> <%s>\n", iface_msg, state_msg);
+	pr_debug("putting nlmsg: <%s> <%s> <%s> <%s>\n", iface_msg, state_msg,
+		 timestamp_msg, uid_msg);
 	kobject_uevent_env(idletimer_tg_kobj, KOBJ_CHANGE, envp);
 	return;
 
@@ -298,6 +312,7 @@ static int idletimer_tg_create(struct idletimer_tg_info *info)
 	info->timer->delayed_timer_trigger.tv_sec = 0;
 	info->timer->delayed_timer_trigger.tv_nsec = 0;
 	info->timer->work_pending = false;
+	info->timer->uid = 0;
 	get_monotonic_boottime(&info->timer->last_modified_timer);
 
 	info->timer->pm_nb.notifier_call = idletimer_resume;
@@ -321,7 +336,8 @@ out:
 	return ret;
 }
 
-static void reset_timer(const struct idletimer_tg_info *info)
+static void reset_timer(const struct idletimer_tg_info *info,
+			struct sk_buff *skb)
 {
 	unsigned long now = jiffies;
 	struct idletimer_tg *timer = info->timer;
@@ -334,6 +350,17 @@ static void reset_timer(const struct idletimer_tg_info *info)
 	if (!timer_prev || time_before(timer->timer.expires, now)) {
 		pr_debug("Starting Checkentry timer (Expired, Jiffies): %lu, %lu\n",
 				timer->timer.expires, now);
+
+		/* Stores the uid resposible for waking up the radio */
+		if (skb && (skb->sk)) {
+			struct sock *sk = skb->sk;
+			read_lock_bh(&sk->sk_callback_lock);
+			if ((sk->sk_socket) && (sk->sk_socket->file) &&
+		    (sk->sk_socket->file->f_cred))
+				timer->uid = sk->sk_socket->file->f_cred->uid;
+			read_unlock_bh(&sk->sk_callback_lock);
+		}
+
 		/* checks if there is a pending inactive notification*/
 		if (timer->work_pending)
 			timer->delayed_timer_trigger = timer->last_modified_timer;
@@ -372,7 +399,7 @@ static unsigned int idletimer_tg_target(struct sk_buff *skb,
 	}
 
 	/* TODO: Avoid modifying timers on each packet */
-	reset_timer(info);
+	reset_timer(info, skb);
 	return XT_CONTINUE;
 }
 
@@ -400,7 +427,7 @@ static int idletimer_tg_checkentry(const struct xt_tgchk_param *par)
 	info->timer = __idletimer_tg_find_by_label(info->label);
 	if (info->timer) {
 		info->timer->refcnt++;
-		reset_timer(info);
+		reset_timer(info, NULL);
 		pr_debug("increased refcnt of timer %s to %u\n",
 			 info->label, info->timer->refcnt);
 	} else {


### PR DESCRIPTION
Message notifications contains an additional uid field. This field
represents the uid that was responsible for waking the radio. And hence
it is present only in notifications stating that the radio is now
active.

Change-Id: I18fc73eada512e370d7ab24fc9f890845037b729
Signed-off-by: Ruchi Kandoi <kandoiruchi@google.com>
Bug: 20264396